### PR TITLE
プレイヤーの諸々

### DIFF
--- a/client/components/containers/menu/AddItemToPlaylistMenu.vue
+++ b/client/components/containers/menu/AddItemToPlaylistMenu.vue
@@ -115,16 +115,10 @@ export default Vue.extend({
         description: '',
         uriList: this.uriList,
       }).then(() => {
-        this.$toast.push({
-          color: 'primary',
-          message: `"${title}" を新規プレイリストに追加しました。`,
-        });
+        this.$toast.pushPrimary(`"${title}" を新規プレイリストに追加しました。`);
       }).catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: `"${title}" を新規プレイリストに追加できませんでした。`,
-        });
+        this.$toast.pushError(`"${title}" を新規プレイリストに追加できませんでした。`);
       });
     },
     onItemClicked(playlist: SpotifyAPI.SimplePlaylist) {

--- a/client/components/containers/menu/EpisodeMenu.vue
+++ b/client/components/containers/menu/EpisodeMenu.vue
@@ -76,6 +76,7 @@ export default Vue.extend({
         handler: () => {
           this.$spotify.player.addItemToQueue({
             uri: this.episode.uri,
+            deviceId: this.$getters()['playback/playbackDeviceId'],
           }).then(() => {
             this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
           }).catch((err: Error) => {

--- a/client/components/containers/menu/EpisodeMenu.vue
+++ b/client/components/containers/menu/EpisodeMenu.vue
@@ -77,16 +77,10 @@ export default Vue.extend({
           this.$spotify.player.addItemToQueue({
             uri: this.episode.uri,
           }).then(() => {
-            this.$toast.push({
-              color: 'primary',
-              message: `"${trackName}" を次に再生に追加しました。`,
-            });
+            this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
           }).catch((err: Error) => {
             console.error({ err });
-            this.$toast.push({
-              color: 'error',
-              message: `"${trackName}" を次に再生に追加できませんでした。`,
-            });
+            this.$toast.pushError(`"${trackName}" を次に再生に追加できませんでした。`);
           });
         },
       };

--- a/client/components/containers/menu/PlaybackMenu.vue
+++ b/client/components/containers/menu/PlaybackMenu.vue
@@ -201,7 +201,7 @@ export default Vue.extend({
           this.isLoading = true;
           Promise.all([
             this.$dispatch('playback/getCurrentPlayback'),
-            this.$dispatch('playback/getActiveDeviceList'),
+            this.$dispatch('playback/getDeviceList'),
           ]).then(() => {
             this.isLoading = false;
           });

--- a/client/components/containers/menu/PlaybackMenu.vue
+++ b/client/components/containers/menu/PlaybackMenu.vue
@@ -60,7 +60,10 @@ export default Vue.extend({
         type,
         name,
         handler: () => {
-          this.$spotify.player.addItemToQueue({ uri })
+          this.$spotify.player.addItemToQueue({
+            uri,
+            deviceId: this.$getters()['playback/playbackDeviceId'],
+          })
             .then(() => {
               this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
             })

--- a/client/components/containers/menu/PlaybackMenu.vue
+++ b/client/components/containers/menu/PlaybackMenu.vue
@@ -62,17 +62,11 @@ export default Vue.extend({
         handler: () => {
           this.$spotify.player.addItemToQueue({ uri })
             .then(() => {
-              this.$toast.push({
-                color: 'primary',
-                message: `"${trackName}" を次に再生に追加しました。`,
-              });
+              this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
             })
             .catch((err: Error) => {
               console.error({ err });
-              this.$toast.push({
-                color: 'error',
-                message: `"${trackName}" を次に再生に追加できませんでした。`,
-              });
+              this.$toast.pushError(`"${trackName}" を次に再生に追加できませんでした。`);
             });
         },
       };

--- a/client/components/containers/menu/PlaylistMenu.vue
+++ b/client/components/containers/menu/PlaylistMenu.vue
@@ -77,20 +77,14 @@ export default Vue.extend({
             playlistId: this.playlist.id,
             isCollaborative,
           }).then(() => {
-            this.$toast.push({
-              color: 'primary',
-              message: isCollaborative
-                ? 'コラボプレイリストにしました。'
-                : 'コラボプレイリストを解除しました。',
-            });
+            this.$toast.pushPrimary(isCollaborative
+              ? 'コラボプレイリストにしました。'
+              : 'コラボプレイリストを解除しました。');
           }).catch((err: Error) => {
             console.error({ err });
-            this.$toast.push({
-              color: 'error',
-              message: isCollaborative
-                ? 'コラボプレイリストにできませんでした。'
-                : 'コラボプレイリストを解除できませんでした。',
-            });
+            this.$toast.pushError(isCollaborative
+              ? 'コラボプレイリストにできませんでした。'
+              : 'コラボプレイリストを解除できませんでした。');
           });
         },
       };
@@ -108,20 +102,14 @@ export default Vue.extend({
             playlistId: this.playlist.id,
             isPublic: !this.playlist.isPublic,
           }).then(() => {
-            this.$toast.push({
-              color: 'primary',
-              message: isPublic
-                ? 'プレイリストを公開しました。'
-                : 'プレイリストを非公開にしました。',
-            });
+            this.$toast.pushPrimary(isPublic
+              ? 'プレイリストを公開しました。'
+              : 'プレイリストを非公開にしました。');
           }).catch((err: Error) => {
             console.error({ err });
-            this.$toast.push({
-              color: 'error',
-              message: isPublic
-                ? 'プレイリストの公開に失敗しました。'
-                : 'プレイリストを非公開にできませんでした。',
-            });
+            this.$toast.pushError(isPublic
+              ? 'プレイリストの公開に失敗しました。'
+              : 'プレイリストを非公開にできませんでした。');
           });
         },
         disabled: this.playlist.isCollaborative,
@@ -164,16 +152,10 @@ export default Vue.extend({
           name,
           uriList: this.playlist.trackUriList,
         }).then(() => {
-          this.$toast.push({
-            color: 'primary',
-            message: `"${name}" を作成しました。`,
-          });
+          this.$toast.pushPrimary(`"${name}" を作成しました。`);
         }).catch((err: Error) => {
           console.error({ err });
-          this.$toast.push({
-            color: 'error',
-            message: err.message,
-          });
+          this.$toast.pushError(err.message);
         });
       };
       return {

--- a/client/components/containers/menu/TrackMenu.vue
+++ b/client/components/containers/menu/TrackMenu.vue
@@ -85,6 +85,7 @@ export default Vue.extend({
         handler: () => {
           this.$spotify.player.addItemToQueue({
             uri: this.track.uri,
+            deviceId: this.$getters()['playback/playbackDeviceId'],
           }).then(() => {
             this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
           }).catch((err: Error) => {

--- a/client/components/containers/menu/TrackMenu.vue
+++ b/client/components/containers/menu/TrackMenu.vue
@@ -86,16 +86,10 @@ export default Vue.extend({
           this.$spotify.player.addItemToQueue({
             uri: this.track.uri,
           }).then(() => {
-            this.$toast.push({
-              color: 'primary',
-              message: `"${trackName}" を次に再生に追加しました。`,
-            });
+            this.$toast.pushPrimary(`"${trackName}" を次に再生に追加しました。`);
           }).catch((err: Error) => {
             console.error({ err });
-            this.$toast.push({
-              color: 'error',
-              message: `"${trackName}" を次に再生に追加できませんでした。`,
-            });
+            this.$toast.pushError(`"${trackName}" を次に再生に追加できませんでした。`);
           });
         },
       };

--- a/client/components/containers/modal/PaylistModal.vue
+++ b/client/components/containers/modal/PaylistModal.vue
@@ -215,16 +215,10 @@ export default Vue.extend({
           artwork: fileReader.result as string,
         }).then(() => {
           this.modal = false;
-          this.$toast.push({
-            color: 'primary',
-            message: `プレイリストを${this.resultText || this.detailText}しました。`,
-          });
+          this.$toast.pushPrimary(`プレイリストを${this.resultText || this.detailText}しました。`);
           this.resetForm();
         }).catch(() => {
-          this.$toast.push({
-            color: 'error',
-            message: '画像のアップロードに失敗しました。',
-          });
+          this.$toast.pushError('画像のアップロードに失敗しました。');
         }).finally(() => {
           this.isLoading = false;
           fileReader.removeEventListener('load', onLoad);
@@ -236,10 +230,7 @@ export default Vue.extend({
       const onError = (err: ProgressEvent<FileReader>) => {
         console.warn(err);
         this.isLoading = false;
-        this.$toast.push({
-          color: 'error',
-          message: '画像の読み込みに失敗しました。',
-        });
+        this.$toast.pushError('画像の読み込みに失敗しました。');
         fileReader.removeEventListener('error', onError);
       };
       fileReader.addEventListener('error', onError);
@@ -285,10 +276,7 @@ export default Vue.extend({
       }).then(() => {
         if (this.playlistArtwork == null) {
           this.modal = false;
-          this.$toast.push({
-            color: 'primary',
-            message: `プレイリストを${this.resultText || this.detailText}しました。`,
-          });
+          this.$toast.pushPrimary(`プレイリストを${this.resultText || this.detailText}しました。`);
           this.resetForm();
         }
       }).finally(() => {

--- a/client/components/containers/player/DeviceSelectMenu.vue
+++ b/client/components/containers/player/DeviceSelectMenu.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
     },
     async updateDeviceList() {
       this.isRefreshingDeviceList = true;
-      await this.$dispatch('playback/getActiveDeviceList');
+      await this.$dispatch('playback/getDeviceList');
       this.isRefreshingDeviceList = false;
     },
     onItemClicked(deviceId: OnItem['click']) {

--- a/client/components/containers/player/DeviceSelectMenu.vue
+++ b/client/components/containers/player/DeviceSelectMenu.vue
@@ -109,10 +109,7 @@ export default Vue.extend({
       if (deviceId != null) {
         this.$dispatch('playback/transferPlayback', { deviceId });
       } else {
-        this.$toast.push({
-          color: 'error',
-          message: 'デバイスを変更できません。',
-        });
+        this.$toast.pushError('デバイスを変更できません。');
       }
     },
   },

--- a/client/components/globals/PlayerBar.pc.vue
+++ b/client/components/globals/PlayerBar.pc.vue
@@ -16,17 +16,18 @@
           :title="trackName"
           :class="$style.Left__artWork"
         />
-
-        <div :class="$style.Left__trackInfo">
+        <div
+          v-if="hasTrack"
+          :class="$style.Left__trackInfo"
+        >
           <MarqueeTrackName
-            v-if="hasTrack"
             :id="trackId"
             :release-id="releaseId"
             :name="trackName"
             :type="trackType"
           />
           <MarqueeArtistNames
-            v-if="isTrack && hasTrack"
+            v-if="isTrack"
             :artists="artists"
           />
         </div>
@@ -53,22 +54,11 @@
         <VolumeSlider />
       </div>
     </div>
-
-    <v-overlay
-      v-if="!loaded"
-      absolute
-      :z-index="$constant.Z_INDEX_OF.loading"
-      :color="$constant.FOOTER_BACKGROUND_COLOR"
-      :opacity="1"
-      :class="$style.Overlay"
-    />
   </v-footer>
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
-import { RootState, RootGetters } from 'typed-vuex';
-
+import { defineComponent, ref, computed } from '@vue/composition-api';
 import ReleaseArtwork from '~/components/parts/image/ReleaseArtwork.vue';
 import MarqueeTrackName from '~/components/parts/text/MarqueeTrackName.vue';
 import MarqueeArtistNames from '~/components/parts/text/MarqueeArtistNames.vue';
@@ -80,11 +70,7 @@ import DeviceSelectMenu from '~/components/containers/player/DeviceSelectMenu.vu
 import PlaybackMenu from '~/components/containers/menu/PlaybackMenu.vue';
 import VolumeSlider from '~/components/containers/player/VolumeSlider.vue';
 
-type Data = {
-  deviceSelectMenu: boolean;
-}
-
-export default Vue.extend({
+export default defineComponent({
   components: {
     ReleaseArtwork,
     MarqueeTrackName,
@@ -98,64 +84,47 @@ export default Vue.extend({
     VolumeSlider,
   },
 
-  props: {
-    loaded: {
-      type: Boolean,
-      required: true,
-    },
-  },
+  setup(_, { root }) {
+    const deviceSelectMenu = ref(false);
 
-  data(): Data {
-    return {
-      deviceSelectMenu: false,
-    };
-  },
+    const artWorkSrc = (size: number) => root.$getters()['playback/artworkSrc'](size);
+    const trackName = computed(() => root.$state().playback.trackName || '不明のトラック');
+    const trackId = computed(() => root.$state().playback.trackId);
+    const trackType = computed(() => root.$state().playback.trackType);
+    const releaseId = computed(() => root.$getters()['playback/releaseId']);
+    const artists = computed(() => root.$state().playback.artists);
+    const isAnotherDevicePlaying = computed(() => root.$getters()['playback/isAnotherDevicePlaying']);
+    const hasTrack = computed(() => root.$getters()['playback/hasTrack']);
+    const isTrack = computed(() => trackType.value === 'track');
 
-  computed: {
-    isAnotherDevicePlaying(): boolean {
-      return this.$getters()['playback/isAnotherDevicePlaying'];
-    },
-    hasTrack(): RootGetters['playback/hasTrack'] {
-      return this.$getters()['playback/hasTrack'];
-    },
-    isTrack(): boolean {
-      return this.trackType === 'track';
-    },
-
-    artWorkSrc(): (size: number) => string | undefined {
-      return (size: number) => this.$getters()['playback/artworkSrc'](size);
-    },
-    trackName(): string {
-      return this.$state().playback.trackName || '不明のトラック';
-    },
-    trackId(): RootState['playback']['trackId'] {
-      return this.$state().playback.trackId;
-    },
-    trackType(): RootState['playback']['trackType'] {
-      return this.$state().playback.trackType;
-    },
-    releaseId(): RootGetters['playback/releaseId'] {
-      return this.$getters()['playback/releaseId'];
-    },
-    artists(): RootState['playback']['artists'] {
-      return this.$state().playback.artists;
-    },
-    isSavedTrack: {
-      get(): RootState['playback']['isSavedTrack'] {
-        return this.$state().playback.isSavedTrack;
-      },
+    const isSavedTrack = computed<boolean>({
+      get() { return root.$state().playback.isSavedTrack; },
       set(isSaved: OnFavorite['input']) {
-        if (this.trackId == null) return;
-
+        const id = trackId.value;
+        if (id == null) return;
         // API との通信の結果を待たずに先に表示を変更させておく
-        this.$commit('playback/SET_IS_SAVED_TRACK', isSaved);
+        root.$commit('playback/SET_IS_SAVED_TRACK', isSaved);
         if (isSaved) {
-          this.$dispatch('library/tracks/saveTracks', [this.trackId]);
+          root.$dispatch('library/tracks/saveTracks', [id]);
         } else {
-          this.$dispatch('library/tracks/removeTracks', [this.trackId]);
+          root.$dispatch('library/tracks/removeTracks', [id]);
         }
       },
-    },
+    });
+
+    return {
+      deviceSelectMenu,
+      isAnotherDevicePlaying,
+      hasTrack,
+      isTrack,
+      artWorkSrc,
+      trackName,
+      trackId,
+      trackType,
+      releaseId,
+      artists,
+      isSavedTrack,
+    };
   },
 });
 </script>

--- a/client/components/globals/PlayerBar.vue
+++ b/client/components/globals/PlayerBar.vue
@@ -1,21 +1,10 @@
 <template>
-  <PlayerBarMobile
-    v-if="$screen.isMobile"
-    :loaded="loaded"
-  />
-  <PlayerBarPc
-    v-else-if="$screen.isPc"
-    :loaded="loaded"
-  />
+  <PlayerBarMobile v-if="$screen.isMobile" />
+  <PlayerBarPc v-else-if="$screen.isPc" />
 </template>
 
 <script lang="ts">
-import {
-  defineComponent,
-  ref,
-  onMounted,
-  onBeforeUnmount,
-} from '@vue/composition-api';
+import { defineComponent, onMounted } from '@vue/composition-api';
 import PlayerBarMobile from '~/components/globals/PlayerBar.mobile.vue';
 import PlayerBarPc from '~/components/globals/PlayerBar.pc.vue';
 
@@ -26,35 +15,7 @@ export default defineComponent({
   },
 
   setup(_, { root }) {
-    const loaded = ref(false);
-
-    let mutationUnsubscribe: (() => void) | undefined;
-    onMounted(() => {
-      root.$dispatch('player/initPlayer');
-      // when a player has already been initialized in a mounted hook, set to true
-      if (root.$getters()['playback/hasTrack']) {
-        loaded.value = true;
-      }
-      mutationUnsubscribe = root.$subscribe((mutation) => {
-        switch (mutation.type) {
-          case 'playback/SET_CURRENT_TRACK':
-            loaded.value = true;
-            if (mutationUnsubscribe != null) {
-              mutationUnsubscribe();
-            }
-            break;
-          default:
-            break;
-        }
-      });
-    });
-    onBeforeUnmount(() => {
-      if (mutationUnsubscribe != null) {
-        mutationUnsubscribe();
-      }
-    });
-
-    return { loaded };
+    onMounted(() => { root.$dispatch('player/initPlayer'); });
   },
 });
 </script>

--- a/client/components/globals/WaveLoader.vue
+++ b/client/components/globals/WaveLoader.vue
@@ -19,16 +19,16 @@
 </template>
 
 <script lang="ts">
-import Vue from 'vue';
+import { defineComponent } from '@vue/composition-api';
 
-export default Vue.extend();
+export default defineComponent({});
 </script>
 
 <style lang="scss" module>
 .WaveLoader {
   position: fixed;
   top: 0;
-  bottom: $g-footer-height-mobile;
+  bottom: 0;
   left: 0;
   right: 0;
   z-index: z-index-of(loading);

--- a/client/components/parts/modal/CreatePlaylistModal.vue
+++ b/client/components/parts/modal/CreatePlaylistModal.vue
@@ -34,12 +34,8 @@ export default Vue.extend({
     const handler = (payload: Parameters<Handler<'create'>>[0]) => this.$dispatch('playlists/createPlaylist', payload)
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: err.message,
-        });
+        this.$toast.pushError(err.message);
       });
-
     return {
       handler,
     };

--- a/client/components/parts/modal/EditPlaylistModal.vue
+++ b/client/components/parts/modal/EditPlaylistModal.vue
@@ -47,12 +47,8 @@ export default Vue.extend({
     const handler = (payload: Parameters<Handler<'edit'>>[0]) => this.$dispatch('playlists/editPlaylist', payload)
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: err.message,
-        });
+        this.$toast.pushError(err.message);
       });
-
     return {
       handler,
     };

--- a/client/observable/toast.ts
+++ b/client/observable/toast.ts
@@ -3,19 +3,21 @@ import Vue from 'vue';
 export type ToastType = 'primary' | 'accent' | 'secondary' | 'info' | 'warning' | 'error' | 'success' | undefined
 
 type Toast = {
-  color?: ToastType
-  message: string
-  timeout?: number
+  color?: ToastType;
+  message: string;
+  timeout?: number;
 }
 
 type ToastState = {
-  toasts: Toast[]
+  toasts: Toast[];
 }
 
 export type $Toast = {
-  toasts: Toast[]
-  push: (toast: Toast) => void
-  set: (toast: Toast) => void
+  toasts: Toast[];
+  push: (toast: Toast) => void;
+  set: (toast: Toast) => void;
+  pushError: (message: string) => void;
+  requirePremium: () => void;
 }
 
 const state = Vue.observable<ToastState>({
@@ -41,5 +43,19 @@ export const $toast: $Toast = {
     if (includedToast == null) {
       state.toasts.push(toast);
     }
+  },
+
+  pushError(message: string) {
+    state.toasts.push({
+      color: 'error',
+      message,
+    });
+  },
+
+  requirePremium() {
+    this.set({
+      color: 'error',
+      message: 'この操作にはプレミアムアカウントが必要です。',
+    });
   },
 };

--- a/client/observable/toast.ts
+++ b/client/observable/toast.ts
@@ -16,8 +16,9 @@ export type $Toast = {
   toasts: Toast[];
   push: (toast: Toast) => void;
   set: (toast: Toast) => void;
-  pushError: (message: string) => void;
-  requirePremium: () => void;
+  pushError: (message: string, timeout?: number) => void;
+  pushPrimary: (message: string, timeout?: number) => void;
+  requirePremium: (message?: string) => void;
 }
 
 const state = Vue.observable<ToastState>({
@@ -45,17 +46,26 @@ export const $toast: $Toast = {
     }
   },
 
-  pushError(message: string) {
+  pushError(message: string, timeout?: number) {
     state.toasts.push({
       color: 'error',
       message,
+      timeout,
     });
   },
 
-  requirePremium() {
+  pushPrimary(message: string, timeout?: number) {
+    state.toasts.push({
+      color: 'primary',
+      message,
+      timeout,
+    });
+  },
+
+  requirePremium(message?: string) {
     this.set({
       color: 'error',
-      message: 'この操作にはプレミアムアカウントが必要です。',
+      message: message ?? 'この操作にはプレミアムアカウントが必要です。',
     });
   },
 };

--- a/client/pages/releases/_releaseId.vue
+++ b/client/pages/releases/_releaseId.vue
@@ -306,11 +306,7 @@ export default class ReleaseIdPage extends Vue implements AsyncData, Data {
       offset,
     });
     if (tracks == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'トラックが取得できませんでした。',
-      });
-
+      this.$toast.pushError('トラックが取得できませんでした。');
       this.releaseInfo = {
         ...releaseInfo,
         isFullTrackList: true,

--- a/client/pages/shows/_showId.vue
+++ b/client/pages/shows/_showId.vue
@@ -270,11 +270,7 @@ export default class ShowIdPage extends Vue implements AsyncData, Data {
       offset,
     });
     if (episodes == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'エピソードが取得できませんでした。',
-      });
-
+      this.$toast.pushError('エピソードが取得できませんでした。');
       this.showInfo = {
         ...showInfo,
         isFullEpisodeList: true,

--- a/client/pages/users/_userId.vue
+++ b/client/pages/users/_userId.vue
@@ -253,13 +253,9 @@ export default class UserIdPage extends Vue implements AsyncData, Data {
       this.isFollowing = nextFollowingState;
     }).catch((err: Error) => {
       console.error({ err });
-      const message = nextFollowingState
+      this.$toast.pushError(nextFollowingState
         ? 'ユーザーをフォローすることができませんでした。'
-        : 'ユーザーのフォローを解除することができませんでした。';
-      this.$toast.push({
-        color: 'error',
-        message,
-      });
+        : 'ユーザーのフォローを解除することができませんでした。');
     });
   }
 }

--- a/client/services/local/_releaseId/getTrackListHandler.ts
+++ b/client/services/local/_releaseId/getTrackListHandler.ts
@@ -34,10 +34,7 @@ export const getTrackListHandler = ({ app, params }: Context) => async (
     offset,
   });
   if (tracks == null) {
-    app.$toast.push({
-      color: 'error',
-      message: 'トラックが取得できませんでした。',
-    });
+    app.$toast.pushError('トラックが取得できませんでした。');
 
     return {
       trackList: [],

--- a/client/services/spotify/player/addItemToQueue.ts
+++ b/client/services/spotify/player/addItemToQueue.ts
@@ -8,7 +8,7 @@ export const addItemToQueue = (context: Context) => {
    */
   return ({ uri, deviceId }: {
     uri: string;
-    deviceId?: string;
+    deviceId: string | undefined;
   }): Promise<void> => {
     return app.$spotifyApi.$post<void>('/me/player/queue', undefined, {
       params: {

--- a/client/services/spotify/player/getDeviceList.ts
+++ b/client/services/spotify/player/getDeviceList.ts
@@ -3,7 +3,7 @@ import { SpotifyAPI } from '~~/types';
 
 type Devices = { devices: SpotifyAPI.Device[] };
 
-export const getActiveDeviceList = (context: Context) => {
+export const getDeviceList = (context: Context) => {
   const { app } = context;
 
   return (): Promise<Partial<Devices>> => {

--- a/client/services/spotify/player/index.ts
+++ b/client/services/spotify/player/index.ts
@@ -1,7 +1,7 @@
 import { Context } from '@nuxt/types';
 
 import { addItemToQueue } from './addItemToQueue';
-import { getActiveDeviceList } from './getActiveDeviceList';
+import { getDeviceList } from './getDeviceList';
 import { getCurrentPlayback } from './getCurrentPlayback';
 import { getRecentlyPlayed } from './getRecentlyPlayed';
 import { next } from './next';
@@ -16,7 +16,7 @@ import { transferPlayback } from './transferPlayback';
 
 export const player = (context: Context) => ({
   addItemToQueue: addItemToQueue(context),
-  getActiveDeviceList: getActiveDeviceList(context),
+  getDeviceList: getDeviceList(context),
   getCurrentPlayback: getCurrentPlayback(context),
   getRecentlyPlayed: getRecentlyPlayed(context),
   next: next(context),

--- a/client/services/spotify/player/next.ts
+++ b/client/services/spotify/player/next.ts
@@ -3,7 +3,7 @@ import { Context } from '@nuxt/types';
 export const next = (context: Context) => {
   const { app } = context;
 
-  return (params?: { deviceId?: string | undefined }): Promise<void> => {
+  return (params: { deviceId: string | undefined }): Promise<void> => {
     return app.$spotifyApi.$post<void>('/me/player/next', undefined, {
       params,
     }).catch((err: Error) => {

--- a/client/services/spotify/player/pause.ts
+++ b/client/services/spotify/player/pause.ts
@@ -3,7 +3,7 @@ import { Context } from '@nuxt/types';
 export const pause = (context: Context) => {
   const { app } = context;
 
-  return (params?: { deviceId?: string | undefined } | undefined): Promise<void> => {
+  return (params: { deviceId: string | undefined } | undefined): Promise<void> => {
     const device_id = params?.deviceId;
     return app.$spotifyApi.$put<void>('/me/player/pause', undefined, {
       params: {

--- a/client/services/spotify/player/play.ts
+++ b/client/services/spotify/player/play.ts
@@ -14,7 +14,7 @@ export const play = (context: Context) => {
     offset,
     positionMs,
   }: {
-    deviceId?: string | undefined;
+    deviceId: string | undefined;
     contextUri?: string;
     trackUriList?: string[];
     offset?: { uri: string } | { position: number };

--- a/client/services/spotify/player/previous.ts
+++ b/client/services/spotify/player/previous.ts
@@ -3,7 +3,7 @@ import { Context } from '@nuxt/types';
 export const previous = (context: Context) => {
   const { app } = context;
 
-  return (params?: { deviceId?: string | undefined }): Promise<void> => {
+  return (params: { deviceId: string | undefined }): Promise<void> => {
     return app.$spotifyApi.$post<void>('/me/player/previous', undefined, {
       params,
     }).catch((err: Error) => {

--- a/client/services/spotify/player/repeat.ts
+++ b/client/services/spotify/player/repeat.ts
@@ -9,7 +9,7 @@ export const repeat = (context: Context) => {
     deviceId,
     state,
   }: {
-    deviceId?: string | undefined;
+    deviceId: string | undefined;
     state: SpotifyAPI.RepeatState;
   }): Promise<void> => {
     return app.$spotifyApi.$put<void>('/me/player/repeat', undefined, {

--- a/client/services/spotify/player/seek.ts
+++ b/client/services/spotify/player/seek.ts
@@ -7,7 +7,7 @@ export const seek = (context: Context) => {
     deviceId,
     positionMs,
   }: {
-    deviceId?: string | undefined;
+    deviceId: string | undefined;
     positionMs: number;
   }): Promise<void> => {
     return app.$spotifyApi.$put<void>('/me/player/seek', undefined, {

--- a/client/services/spotify/player/shuffle.ts
+++ b/client/services/spotify/player/shuffle.ts
@@ -7,7 +7,7 @@ export const shuffle = (context: Context) => {
     deviceId,
     state,
   }: {
-    deviceId?: string | undefined;
+    deviceId: string | undefined;
     state: boolean;
   }): Promise<void> => {
     return app.$spotifyApi.$put<void>('/me/player/shuffle', undefined, {

--- a/client/services/spotify/player/volume.ts
+++ b/client/services/spotify/player/volume.ts
@@ -8,7 +8,7 @@ export const volume = (context: Context) => {
     deviceId,
     volumePercent,
   }: {
-    deviceId?: string | undefined;
+    deviceId: string | undefined;
     volumePercent: ZeroToHundred;
   }): Promise<void> => {
     return app.$spotifyApi.$put<void>('/me/player/volume', undefined, {

--- a/client/services/use/observer/index.ts
+++ b/client/services/use/observer/index.ts
@@ -1,1 +1,2 @@
+export * from './useIntersectionObserver';
 export * from './useRisizableVirtualScroll';

--- a/client/services/use/observer/useIntersectionObserver.ts
+++ b/client/services/use/observer/useIntersectionObserver.ts
@@ -1,0 +1,32 @@
+import { watchEffect, Ref, onBeforeUnmount } from '@vue/composition-api';
+
+export const useIntersectionObserver = (
+  elementRef: Ref<HTMLElement | undefined | null>,
+  callback: (entry: IntersectionObserverEntry) => void,
+  options?: IntersectionObserverInit,
+) => {
+  let observer: IntersectionObserver | undefined;
+  const stop = watchEffect((onInvalidate) => {
+    if (typeof IntersectionObserver !== 'undefined') {
+      observer = new IntersectionObserver((entries) => {
+        entries.forEach(callback);
+      }, options);
+      const element = elementRef.value;
+      if (element != null) {
+        observer.observe(element);
+      }
+    }
+
+    onInvalidate(() => {
+      if (observer != null) {
+        observer.disconnect();
+      }
+    });
+  });
+
+  onBeforeUnmount(() => {
+    stop();
+  });
+
+  return stop;
+};

--- a/client/services/use/util/useCopyText.ts
+++ b/client/services/use/util/useCopyText.ts
@@ -3,21 +3,14 @@ import { SetupContext } from '@vue/composition-api';
 export const useCopyText = (root: SetupContext['root'], text: string, name: string): void => {
   const copyEventListener = (e: ClipboardEvent) => {
     if (e.clipboardData == null) {
-      root.$toast.push({
-        color: 'error',
-        message: `${name}をコピーできませんでした。`,
-      });
+      root.$toast.pushError(`${name}をコピーできませんでした。`);
       return;
     }
-
     e.preventDefault();
     e.clipboardData.setData('text/plain', text);
     document.removeEventListener('copy', copyEventListener);
 
-    root.$toast.push({
-      color: 'primary',
-      message: `${name}をコピーしました。`,
-    });
+    root.$toast.pushPrimary(`${name}をコピーしました。`);
   };
 
   document.addEventListener('copy', copyEventListener);

--- a/client/store/auth/actions.ts
+++ b/client/store/auth/actions.ts
@@ -46,12 +46,8 @@ const actions: Actions<AuthState, AuthActions, AuthGetters, AuthMutations> = {
       window.location.href = data.url;
       return;
     }
-
     console.error('トークン取得時にエラーが発生しました。');
-    this.$toast.push({
-      color: 'error',
-      message: 'トークン取得時にエラーが発生し、ログインできません。',
-    });
+    this.$toast.pushError('トークン取得時にエラーが発生し、ログインできません。');
   },
 
   async exchangeCodeToAccessToken({ commit }, { code, state }) {
@@ -108,10 +104,7 @@ const actions: Actions<AuthState, AuthActions, AuthGetters, AuthMutations> = {
           commit('SET_EXPIRATION_MS', undefined);
           await dispatch('logout');
           this.$router.push('/login');
-          this.$toast.push({
-            color: 'error',
-            message: 'トークンを取得できなかったためログアウトしました。',
-          });
+          this.$toast.pushError('トークンを取得できなかったためログアウトしました。');
         } else if (err.response?.status === 409) {
           // コンフリクトして現在のトークンが一致しない場合 (409) は再取得
           await dispatch('getAccessToken');

--- a/client/store/auth/actions.ts
+++ b/client/store/auth/actions.ts
@@ -16,7 +16,7 @@ export type AuthActions = {
   getAccessToken: () => Promise<void>
   refreshAccessToken: () => Promise<void>
   logout: () => Promise<void>
-  confirmAuthState: () => Promise<boolean>
+  confirmAuthState: (params?: { checkPremium?: boolean } | undefined) => Promise<boolean>
 }
 
 export type RootActions = {
@@ -136,11 +136,13 @@ const actions: Actions<AuthState, AuthActions, AuthGetters, AuthMutations> = {
     dispatch('playback/resetPlayback', undefined, { root: true });
   },
 
-  async confirmAuthState({ getters, dispatch }) {
+  async confirmAuthState({ getters, dispatch }, params) {
     if (!getters.isLoggedin || getters.isTokenExpired()) {
       await dispatch('refreshAccessToken');
     }
-    return getters.isLoggedin;
+    return params?.checkPremium
+      ? getters.isLoggedin && getters.isPremium
+      : getters.isLoggedin;
   },
 };
 

--- a/client/store/auth/getters.ts
+++ b/client/store/auth/getters.ts
@@ -6,6 +6,7 @@ import { SpotifyAPI } from '~~/types';
 
 export type AuthGetters = {
   isLoggedin: boolean
+  isPremium: boolean
   isTokenExpired: () => boolean
   finishedRefreshingToken: Promise<true>
   userId: string | undefined
@@ -16,6 +17,7 @@ export type AuthGetters = {
 
 export type RootGetters = {
   'auth/isLoggedin': AuthGetters['isLoggedin']
+  'auth/isPremium': AuthGetters['isPremium']
   'auth/isTokenExpired': AuthGetters['isTokenExpired']
   'auth/finishedRefreshingToken': AuthGetters['finishedRefreshingToken']
   'auth/userId': AuthGetters['userId']
@@ -27,6 +29,10 @@ export type RootGetters = {
 const getters: Getters<AuthState, AuthGetters> = {
   isLoggedin(state) {
     return state.accessToken != null && state.userData != null;
+  },
+
+  isPremium(state) {
+    return state.userData?.product === 'premium';
   },
 
   // 関数実行時に Date.now() が評価されるようにする

--- a/client/store/library/artists/actions.ts
+++ b/client/store/library/artists/actions.ts
@@ -52,11 +52,7 @@ const actions: Actions<
       after,
     });
     if (artists == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'フォロー中のアーティストの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('フォロー中のアーティストの一覧を取得できませんでした。');
       return;
     }
 
@@ -88,10 +84,7 @@ const actions: Actions<
       limit: Math.min(unupdatedCounts, maxLimit) as TODO,
     });
     if (artists == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'フォロー中のアーティストの一覧を更新できませんでした。',
-      });
+      this.$toast.pushError('フォロー中のアーティストの一覧を更新できませんでした。');
 
       return;
     }
@@ -123,10 +116,7 @@ const actions: Actions<
       idList,
     }).catch((err: Error) => {
       console.error({ err });
-      this.$toast.push({
-        color: 'error',
-        message: 'フォローに失敗しました。',
-      });
+      this.$toast.pushError('フォローに失敗しました。');
     });
 
     idList.forEach((artistId) => {
@@ -149,10 +139,7 @@ const actions: Actions<
       idList,
     }).catch((err: Error) => {
       console.error({ err });
-      this.$toast.push({
-        color: 'error',
-        message: 'フォローの解除に失敗しました。',
-      });
+      this.$toast.pushError('フォローの解除に失敗しました。');
     });
 
     idList.forEach((artistId) => {

--- a/client/store/library/releases/actions.ts
+++ b/client/store/library/releases/actions.ts
@@ -62,11 +62,7 @@ const actions: Actions<
       market,
     });
     if (releases == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのアルバムの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのアルバムの一覧を取得できませんでした。');
       return;
     }
 
@@ -122,11 +118,7 @@ const actions: Actions<
     }, EMPTY_PAGING as LibraryOfReleases));
 
     if (releases == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのアルバムの一覧を更新できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのアルバムの一覧を更新できませんでした。');
       return;
     }
 
@@ -155,10 +147,7 @@ const actions: Actions<
     await this.$spotify.library.saveAlbums({ albumIdList })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'ライブラリにアルバムを保存できませんでした。',
-        });
+        this.$toast.pushError('ライブラリにアルバムを保存できませんでした。');
       });
 
     albumIdList.forEach((releaseId) => {
@@ -179,10 +168,7 @@ const actions: Actions<
     await this.$spotify.library.removeUserSavedAlbums({ albumIdList })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'ライブラリからアルバムを削除できませんでした。',
-        });
+        this.$toast.pushError('ライブラリからアルバムを削除できませんでした。');
       });
 
     albumIdList.forEach((releaseId) => {

--- a/client/store/library/shows/actions.ts
+++ b/client/store/library/shows/actions.ts
@@ -58,11 +58,7 @@ const actions: Actions<
       market,
     });
     if (shows == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのポッドキャストの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのポッドキャストの一覧を取得できませんでした。');
       return;
     }
 
@@ -117,11 +113,7 @@ const actions: Actions<
     }, EMPTY_PAGING as LibraryOfShows));
 
     if (shows == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのエピソードの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのエピソードの一覧を取得できませんでした。');
       return;
     }
 
@@ -148,10 +140,7 @@ const actions: Actions<
     await this.$spotify.library.saveShows({ showIdList })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エピソードをフォローできませんでした。',
-        });
+        this.$toast.pushError('エピソードをフォローできませんでした。');
       });
 
     showIdList.forEach((showId) => {
@@ -172,10 +161,7 @@ const actions: Actions<
     await this.$spotify.library.removeUserSavedShows({ showIdList })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エピソードのフォローを解除できませんでした。',
-        });
+        this.$toast.pushError('エピソードのフォローを解除できませんでした。');
       });
 
     showIdList.forEach((showId) => {

--- a/client/store/library/tracks/actions.ts
+++ b/client/store/library/tracks/actions.ts
@@ -60,11 +60,7 @@ const actions: Actions<
       market,
     });
     if (tracks == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのトラックの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのトラックの一覧を取得できませんでした。');
       return;
     }
 
@@ -125,11 +121,7 @@ const actions: Actions<
     }, EMPTY_PAGING as LibraryOfTracks));
 
     if (tracks == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'お気に入りのトラックの一覧を更新できませんでした。',
-      });
-
+      this.$toast.pushError('お気に入りのトラックの一覧を更新できませんでした。');
       return;
     }
 
@@ -183,10 +175,7 @@ const actions: Actions<
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'ライブラリにトラックを保存できませんでした。',
-        });
+        this.$toast.pushError('ライブラリにトラックを保存できませんでした。');
       });
   },
 
@@ -208,10 +197,7 @@ const actions: Actions<
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'ライブラリからトラックを削除できませんでした。',
-        });
+        this.$toast.pushError('ライブラリからトラックを削除できませんでした。');
       });
   },
 

--- a/client/store/playback/actions.ts
+++ b/client/store/playback/actions.ts
@@ -266,10 +266,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     if (playbackState.device.id !== currentActiveDeviceId) {
       dispatch('getDeviceList')
         .then(() => {
-          this.$toast.push({
-            color: 'primary',
-            message: 'デバイスの変更を検知しました。',
-          });
+          this.$toast.pushPrimary('デバイスの変更を検知しました。');
         });
     }
     return playbackState;
@@ -340,10 +337,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     if (getters.isDisallowed('resuming') && payload == null) {
       // @todo resuming が禁止されるのは再生中である場合に限らない (ネットワークエラーなど)
       // commit('SET_IS_PLAYING', true);
-      this.$toast.push({
-        color: 'error',
-        message: 'トラックを再生できません',
-      });
+      this.$toast.pushError('トラックを再生できません');
       return;
     }
 
@@ -394,23 +388,14 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
           await dispatch('transferPlayback');
           return request();
         }
-
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、トラックを再生できません。',
-        });
-
+        this.$toast.pushError('エラーが発生し、トラックを再生できません。');
         dispatch('pollCurrentPlayback', 0);
         return undefined;
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、トラックを再生できません。',
-        });
-
+        this.$toast.pushError('エラーが発生し、トラックを再生できません。');
         dispatch('pollCurrentPlayback', 0);
       });
   },
@@ -435,10 +420,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生しました。',
-        });
+        this.$toast.pushError('エラーが発生しました。');
         dispatch('pollCurrentPlayback', 0);
       }).finally(() => {
         // エラーが発生しても表示は停止させる
@@ -467,10 +449,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     await this.$spotify.player.seek({ positionMs })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生しました。',
-        });
+        this.$toast.pushError('エラーが発生しました。');
         // 現在の position に戻す
         commit('SET_POSITION_MS', currentPositionMs ?? positionMsOfCurrentState);
       })
@@ -493,10 +472,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     await this.$spotify.player.next()
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、次の曲を再生できません。',
-        });
+        this.$toast.pushError('エラーが発生し、次の曲を再生できません。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {
@@ -517,10 +493,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     await this.$spotify.player.previous()
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、前の曲を再生できません。',
-        });
+        this.$toast.pushError('エラーが発生し、前の曲を再生できません。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {
@@ -554,10 +527,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
         commit('SET_IS_SHUFFLED', nextIsShuffled);
       }).catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、シャッフルのモードを変更できませんでした。',
-        });
+        this.$toast.pushError('エラーが発生し、シャッフルのモードを変更できませんでした。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {
@@ -594,10 +564,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、リピートのモードを変更できませんでした。',
-        });
+        this.$toast.pushError('エラーが発生し、リピートのモードを変更できませんでした。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {
@@ -630,10 +597,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、ボリュームが変更できませんでした。',
-        });
+        this.$toast.pushError('エラーが発生し、ボリュームが変更できませんでした。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {
@@ -671,10 +635,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'エラーが発生し、ボリュームをミュートにできませんでした。',
-        });
+        this.$toast.pushError('エラーが発生し、ボリュームをミュートにできませんでした。');
       })
       .finally(() => {
         if (!getters.isThisAppPlaying) {

--- a/client/store/playback/actions.ts
+++ b/client/store/playback/actions.ts
@@ -4,7 +4,7 @@ import { PlaybackState } from './state';
 import { PlaybackGetters } from './getters';
 import { PlaybackMutations } from './mutations';
 import { REPEAT_STATE_LIST } from '~/constants';
-import { SpotifyAPI, ZeroToHundred } from '~~/types';
+import type { SpotifyAPI, ZeroToHundred } from '~~/types';
 
 export type PlaybackActions = {
   transferPlayback: (params?: {
@@ -12,7 +12,8 @@ export type PlaybackActions = {
     play?: boolean
     update?: true
   }) => Promise<void>
-  getActiveDeviceList: () => Promise<void>
+  getDeviceList: () => Promise<void>
+  updateDeviceList: (deviceId: string) => Promise<void>
   setCustomContext: (params: {
     contextUri?: string
     trackUriList: string[]
@@ -21,7 +22,7 @@ export type PlaybackActions = {
   resetCustomContext: (uri: string | null) => void
   getCurrentPlayback: () => Promise<SpotifyAPI.Player.CurrentPlayback | undefined>
   pollCurrentPlayback: (timeout?: number) => void
-  play: (payload?: (
+  play: (params?: (
     { contextUri: string; trackUriList?: undefined }
     | { contextUri?: undefined; trackUriList: string[] }
   ) & {
@@ -29,7 +30,7 @@ export type PlaybackActions = {
       | { uri?: undefined; position: number }
   }) => Promise<void>
   pause: () => Promise<void>
-  seek: (payload: {
+  seek: (params: {
     positionMs: number
     currentPositionMs?: number
   }) => Promise<void>
@@ -37,10 +38,10 @@ export type PlaybackActions = {
   previous: () => Promise<void>
   shuffle: () => Promise<void>
   repeat: () => Promise<void>
-  volume: ({ volumePercent }: { volumePercent: ZeroToHundred }) => Promise<void>
+  volume: (params: { volumePercent: ZeroToHundred }) => Promise<void>
   mute: () => Promise<void>
   checkTrackSavedState: (trackIds?: string) => Promise<void>
-  modifyTrackSavedState: ({ trackId, isSaved }: {
+  modifyTrackSavedState: (params: {
     trackId?: string
     isSaved: boolean
   }) => void
@@ -49,7 +50,7 @@ export type PlaybackActions = {
 
 export type RootActions = {
   'playback/transferPlayback': PlaybackActions['transferPlayback']
-  'playback/getActiveDeviceList': PlaybackActions['getActiveDeviceList']
+  'playback/getDeviceList': PlaybackActions['getDeviceList']
   'playback/setCustomContext': PlaybackActions['setCustomContext']
   'playback/resetCustomContext': PlaybackActions['resetCustomContext']
   'playback/getCurrentPlayback': PlaybackActions['getCurrentPlayback']
@@ -76,61 +77,29 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
    * 再生するデバイスを変更し、update が指定されればデバイス一覧も更新
    */
   async transferPlayback({ state, commit, dispatch }, params) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     const thisDeviceId = state.deviceId;
     // 指定されなければこのデバイスに変更
     const deviceId = params?.deviceId ?? thisDeviceId;
     if (deviceId == null) return;
 
-    // 変更するデバイスのボリュームを取得
-    const getVolumePercent = async (
-      deviceList: SpotifyAPI.Device[],
-    ): Promise<ZeroToHundred |undefined> => {
-      // 違うデバイスで再生する場合
-      if (deviceId !== thisDeviceId) {
-        return deviceList.find((device) => device.is_active)?.volume_percent;
-      }
-
-      // @todo 初期化直後だと deviceList のボリュームの値が 100% になっちゃうのでプレイヤーから取得
-      const volume = await this.$state().player.playbackPlayer?.getVolume();
-      return volume != null
-        ? volume * 100 as ZeroToHundred
-        : undefined;
-    };
-
-    // デバイス一覧を更新
-    const updateDeviceList = async () => {
-      if (params?.update) {
-        // デバイスのリストを取得しなおす
-        await dispatch('getActiveDeviceList');
-        return;
-      }
-
-      // 再生されているデバイスの isActive を true にする
-      const deviceList: SpotifyAPI.Device[] = this.$state().playback.deviceList.map((device) => ({
-        ...device,
-        is_active: device.id === deviceId,
-      }));
-      commit('SET_DEVICE_LIST', deviceList);
-
-      const volumePercent = await getVolumePercent(deviceList);
-      if (volumePercent != null) {
-        commit('SET_VOLUME_PERCENT', { volumePercent });
-      }
-    };
-
     // play が指定されなかった場合は、デバイス内の状態を維持し、false が指定された場合は現在の状態を維持
     const play = params?.play ?? state.isPlaying;
     await this.$spotify.player.transferPlayback({ deviceId, play })
       .then(async () => {
         commit('SET_ACTIVE_DEVICE_ID', deviceId);
-
-        // deviceList はまだ前の状態のままなので更新
-        await updateDeviceList();
-
-        // 他のデバイスに変更した場合
+        if (params?.update) {
+          // デバイスのリストを取得しなおす
+          await dispatch('getDeviceList');
+          return;
+        }
+        await dispatch('updateDeviceList', deviceId);
+        // 他のデバイスに変更した場合タイマーをセットしあ雄
         if (deviceId !== thisDeviceId) {
           dispatch('pollCurrentPlayback', 1000);
         }
@@ -139,7 +108,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
         console.error({ err });
         if (deviceId === thisDeviceId) {
           dispatch('player/disconnectPlayer', undefined, { root: true });
-          dispatch('player/initPlayer', undefined, { root: true });
+          // dispatch('player/initPlayer', undefined, { root: true });
         }
       });
   },
@@ -147,16 +116,16 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   /**
    * デバイス一覧とデバイスのボリュームを取得
    */
-  async getActiveDeviceList({ commit, dispatch }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+  async getDeviceList({ commit, dispatch }) {
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
-    const { devices } = await this.$spotify.player.getActiveDeviceList();
-    const deviceList = devices ?? [];
-    const activeDevice = deviceList.find((device) => device.is_active);
-
+    const deviceList = (await this.$spotify.player.getDeviceList()).devices ?? [];
     commit('SET_DEVICE_LIST', deviceList);
-
+    const activeDevice = deviceList.find((device) => device.is_active);
     if (activeDevice != null) {
       // activeDevice がなく、このデバイスで再生する場合は localStorage で永続化されてる volumePercent が採用される
       commit('SET_VOLUME_PERCENT', { volumePercent: activeDevice.volume_percent });
@@ -164,6 +133,44 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       if (activeDevice.id != null) {
         commit('SET_ACTIVE_DEVICE_ID', activeDevice.id);
       }
+    }
+  },
+
+  /**
+   * デバイス一覧を更新
+   */
+  async updateDeviceList({ state, commit, dispatch }, deviceId) {
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
+
+    // 変更するデバイスのボリュームを取得
+    const getVolumePercent = async (
+      deviceList: SpotifyAPI.Device[],
+    ): Promise<ZeroToHundred | undefined> => {
+      // 違うデバイスで再生する場合
+      if (deviceId !== state.deviceId) {
+        return deviceList.find((device) => device.is_active)?.volume_percent;
+      }
+      // @todo 初期化直後だと deviceList のボリュームの値が 100% になっちゃうのでプレイヤーから取得
+      const volume = await this.$state().player.playbackPlayer?.getVolume();
+      return volume != null
+        ? volume * 100 as ZeroToHundred
+        : undefined;
+    };
+
+    // 再生されているデバイスの isActive を true にする
+    const deviceList: SpotifyAPI.Device[] = state.deviceList.map((device) => ({
+      ...device,
+      is_active: device.id === deviceId,
+    }));
+    commit('SET_DEVICE_LIST', deviceList);
+
+    const volumePercent = await getVolumePercent(deviceList);
+    if (volumePercent != null) {
+      commit('SET_VOLUME_PERCENT', { volumePercent });
     }
   },
 
@@ -198,6 +205,12 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
    * Web Playback SDK では取得できるので、このデバイスで再生中の場合はそちらから取得できる
    */
   async getCurrentPlayback({ state, commit, dispatch }) {
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return undefined;
+    }
+
     // currentTrack と durationMs を設定
     const setTrack = (
       item: SpotifyAPI.Track | SpotifyAPI.Episode | null,
@@ -205,12 +218,8 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     ) => {
       // @todo episode 再生中だと null になる
       const track: Spotify.Track | undefined = item?.type === 'track'
-        ? {
-          ...item,
-          media_type: 'audio',
-        }
+        ? { ...item, media_type: 'audio' }
         : undefined;
-
       // このデバイスで再生中でアイテムの内容が取得できなかった場合は Playback SDK の情報を信頼してパスする
       if (track == null && this.$getters()['playback/isThisAppPlaying']) return;
 
@@ -219,7 +228,6 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       if (trackId != null && trackId !== currentTrackId) {
         dispatch('checkTrackSavedState', trackId);
       }
-
       commit('SET_CURRENT_TRACK', track);
       commit('SET_DURATION_MS', item?.duration_ms);
     };
@@ -233,63 +241,37 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       commit('SET_IS_SHUFFLED', playbackState.shuffle_state);
       commit('SET_DISALLOWS', playbackState.actions.disallows);
       commit('SET_POSITION_MS', playbackState.progress_ms ?? 0);
-
       const deviceId = playbackState.device.id;
-      const { deviceId: currentDeviceId } = this.$state().playback;
       // このデバイスで再生中の場合は Web Playback SDK から取得するのでパス
-      if (deviceId == null || deviceId !== currentDeviceId) {
+      if (deviceId == null || deviceId !== this.$state().playback.deviceId) {
         commit('SET_NEXT_TRACK_LIST', []);
         commit('SET_PREVIOUS_TRACK_LIST', []);
       }
     };
 
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return undefined;
-
     const {
-      deviceId: thisDeviceId,
       activeDeviceId: currentActiveDeviceId,
       trackId: currentTrackId,
     } = state;
     // const hasTrack = this.$getters()['playback/hasTrack'];
     const market = this.$getters()['auth/userCountryCode'];
+    // @todo 複数タブ開いた場合はデバイスが消失する場合がある?
     const playbackState = await this.$spotify.player.getCurrentPlayback({ market });
+    // エラー (i.e.トークンの期限切れなど) が発生し、再生状況が取得できなかった場合か、デバイスが見つからない場合
+    if (!playbackState) return playbackState;
 
-    // 何らかのエラー (i.e.トークンの期限切れなど) が発生し、再生状況が取得できなかった場合
-    if (playbackState == null) return undefined;
-
-    // デバイスが見つからないなどの理由で再生状況が取得できない場合
-    if (playbackState === '') {
-      // @todo 複数タブ開いた場合はデバイスが消失する場合がある?
-      await dispatch('transferPlayback', {
-        play: false,
-        update: true,
-      });
-
-      // 他のデバイスからこのデバイスに変更した場合はトーストを表示
-      if (currentActiveDeviceId != null && thisDeviceId !== currentActiveDeviceId) {
-        this.$toast.push({
-          color: 'primary',
-          message: '再生していたデバイスが見つからないため、このデバイスをアクティブにします。',
-        });
-      }
-    } else {
-      setTrack(playbackState.item, currentTrackId);
-      setPlayback(playbackState);
-
-      const activeDeviceId = playbackState.device.id;
-      // アクティブなデバイスのデータに不整合がある場合はデバイス一覧を取得し直す
-      if (activeDeviceId !== currentActiveDeviceId) {
-        dispatch('getActiveDeviceList')
-          .then(() => {
-            this.$toast.push({
-              color: 'primary',
-              message: 'デバイスの変更を検知しました。',
-            });
+    setTrack(playbackState.item, currentTrackId);
+    setPlayback(playbackState);
+    // アクティブなデバイスのデータに不整合がある場合はデバイス一覧を取得し直す
+    if (playbackState.device.id !== currentActiveDeviceId) {
+      dispatch('getDeviceList')
+        .then(() => {
+          this.$toast.push({
+            color: 'primary',
+            message: 'デバイスの変更を検知しました。',
           });
-      }
+        });
     }
-
     return playbackState;
   },
 
@@ -324,35 +306,21 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
         document.addEventListener('visibilitychange', handler);
         return;
       }
-
       document.removeEventListener('visibilitychange', handler);
 
       // getCurrentPlayback する前に再生中のアイテムの情報を保持していていたか
       const previousHasTrack = this.$getters()['playback/hasTrack'];
       const playbackState = await dispatch('getCurrentPlayback');
-
       // 何らかのエラー (i.e.トークンの期限切れなど) が発生し、再生状況が取得できなかった場合は普通にタイマーを設定
-      if (playbackState == null) {
-        setTimer(handler);
-        return;
-      }
+      if (playbackState == null) return;
 
       // @todo 無限にリトライしちゃう
-      const retryTimeout = 2000;
-      // デバイスが見つからないなどの理由で再生状況が取得できない場合はリトライ
-      if (playbackState === '') {
-        setTimer(handler, retryTimeout);
-        return;
-      }
-
       // 再生中のアイテムの情報を保持していて、エピソード以外でアイテムが取得できなかった場合はリトライ
       const shouldRetry = previousHasTrack
+        && playbackState
         && playbackState.item == null
         && playbackState.currently_playing_type !== 'episode';
-
-      setTimer(handler, shouldRetry
-        ? retryTimeout
-        : undefined);
+      setTimer(handler, shouldRetry ? 2000 : undefined);
     };
 
     // firstTimeout ms 経過後、再帰的に getCurrentPlayback を実行
@@ -379,8 +347,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
       return;
     }
 
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     const {
       positionMs,
@@ -406,13 +377,15 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     const params = isNotUriPassed || isRestartingTracks
       ? { positionMs }
       : { contextUri, trackUriList, offset };
-    const request = () => this.$spotify.player.play(params)
-      .then(() => {
-        commit('SET_IS_PLAYING', true);
-        if (!getters.isThisAppPlaying) {
-          dispatch('pollCurrentPlayback', DEFAULT_TIMEOUT);
-        }
-      });
+    const request = () => {
+      return this.$spotify.player.play(params)
+        .then(() => {
+          commit('SET_IS_PLAYING', true);
+          if (!getters.isThisAppPlaying) {
+            dispatch('pollCurrentPlayback', DEFAULT_TIMEOUT);
+          }
+        });
+    };
 
     await request()
       .catch(async (err: Error) => {
@@ -443,8 +416,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   },
 
   async pause({ getters, commit, dispatch }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     if (getters.isDisallowed('pausing')) {
       commit('SET_IS_PLAYING', false);
@@ -463,8 +439,6 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
           color: 'error',
           message: 'エラーが発生しました。',
         });
-
-
         dispatch('pollCurrentPlayback', 0);
       }).finally(() => {
         // エラーが発生しても表示は停止させる
@@ -478,8 +452,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit,
     dispatch,
   }, { positionMs, currentPositionMs }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     if (getters.isDisallowed('seeking')) return;
 
@@ -494,8 +471,6 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
           color: 'error',
           message: 'エラーが発生しました。',
         });
-
-
         // 現在の position に戻す
         commit('SET_POSITION_MS', currentPositionMs ?? positionMsOfCurrentState);
       })
@@ -507,8 +482,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   },
 
   async next({ getters, dispatch }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     if (getters.isDisallowed('skipping_next')) return;
 
@@ -528,8 +506,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
   },
 
   async previous({ getters, dispatch }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     if (getters.isDisallowed('skipping_prev')) return;
 
@@ -557,8 +538,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit,
     dispatch,
   }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     if (getters.isDisallowed('toggling_shuffle')) return;
 
@@ -591,8 +575,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit,
     dispatch,
   }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     // 初回読み込み時は undefined
     if (state.repeatMode == null
@@ -628,8 +615,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit,
     dispatch,
   }, { volumePercent }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     const { volumePercent: currentVolumePercent } = state;
     if (currentVolumePercent === volumePercent) return;
@@ -661,8 +651,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     commit,
     dispatch,
   }) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     const {
       isMuted,
@@ -671,10 +664,7 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     const nextMuteState = !isMuted;
     if (currentVolumePercent === 0) return;
 
-    const volumePercent = nextMuteState
-      ? 0
-      : currentVolumePercent;
-
+    const volumePercent = nextMuteState ? 0 : currentVolumePercent;
     await this.$spotify.player.volume({ volumePercent })
       .then(() => {
         commit('SET_IS_MUTED', nextMuteState);
@@ -697,8 +687,11 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
    * セットされているトラックの保存状態を確認する
    */
   async checkTrackSavedState({ state, commit, dispatch }, trackId?) {
-    const isAuthorized = await dispatch('auth/confirmAuthState', undefined, { root: true });
-    if (!isAuthorized) return;
+    const isAuthorized = await dispatch('auth/confirmAuthState', { checkPremium: true }, { root: true });
+    if (!isAuthorized) {
+      this.$toast.requirePremium();
+      return;
+    }
 
     const id = trackId ?? state.trackId;
     if (id == null) return;
@@ -706,7 +699,6 @@ const actions: Actions<PlaybackState, PlaybackActions, PlaybackGetters, Playback
     const [isSavedTrack] = await this.$spotify.library.checkUserSavedTracks({
       trackIdList: [id],
     });
-
     commit('SET_IS_SAVED_TRACK', isSavedTrack);
   },
 

--- a/client/store/playback/getters.ts
+++ b/client/store/playback/getters.ts
@@ -9,6 +9,7 @@ import { SpotifyAPI, App, ZeroToHundred } from '~~/types';
 
 export type PlaybackGetters = {
   activeDevice: SpotifyAPI.Device | undefined
+  playbackDeviceId: string | undefined
   deviceList: App.DeviceInfo[]
   isThisAppPlaying: boolean
   isAnotherDevicePlaying: boolean
@@ -28,6 +29,7 @@ export type PlaybackGetters = {
 
 export type RootGetters = {
   'playback/activeDevice': PlaybackGetters['activeDevice']
+  'playback/playbackDeviceId': PlaybackGetters['playbackDeviceId']
   'playback/deviceList': PlaybackGetters['deviceList']
   'playback/isThisAppPlaying': PlaybackGetters['isThisAppPlaying']
   'playback/isAnotherDevicePlaying': PlaybackGetters['isAnotherDevicePlaying']
@@ -49,6 +51,12 @@ const playerGetters: Getters<PlaybackState, PlaybackGetters> = {
   activeDevice(state) {
     const activeDevice = state.deviceList.find((device) => device.is_active);
     return activeDevice;
+  },
+
+  playbackDeviceId(state) {
+    return state.isPlaybackSleep
+      ? state.activeDeviceId
+      : undefined;
   },
 
   deviceList(state, getters) {

--- a/client/store/playback/mutations.ts
+++ b/client/store/playback/mutations.ts
@@ -15,6 +15,7 @@ export type PlaybackMutations = {
   SET_DEVICE_ID: string | undefined
   SET_ACTIVE_DEVICE_ID: string | undefined
   SET_DEVICE_LIST: SpotifyAPI.Device[]
+  SET_IS_PLAYBACK_SLEEP: boolean
   SET_CUSTOM_CONTEXT_URI: string | undefined
   SET_CUSTOM_TRACK_URI_LIST: string[] | undefined
   SET_TRACK_INDEX: number | undefined
@@ -39,6 +40,7 @@ export type RootMutations = {
   'playback/SET_DEVICE_ID': PlaybackMutations['SET_DEVICE_ID']
   'playback/SET_ACTIVE_DEVICE_ID': PlaybackMutations['SET_ACTIVE_DEVICE_ID']
   'playback/SET_DEVICE_LIST': PlaybackMutations['SET_DEVICE_LIST']
+  'playback/SET_IS_PLAYBACK_SLEEP': PlaybackMutations['SET_IS_PLAYBACK_SLEEP']
   'playback/SET_CUSTOM_CONTEXT_URI': PlaybackMutations['SET_CUSTOM_CONTEXT_URI']
   'playback/SET_CUSTOM_TRACK_URI_LIST': PlaybackMutations['SET_CUSTOM_TRACK_URI_LIST']
   'playback/SET_TRACK_INDEX': PlaybackMutations['SET_TRACK_INDEX']
@@ -82,6 +84,10 @@ const mutations: Mutations<PlaybackState, PlaybackMutations> = {
 
   SET_DEVICE_LIST(state, deviceList) {
     state.deviceList = deviceList;
+  },
+
+  SET_IS_PLAYBACK_SLEEP(state, isPlaybackSleep) {
+    state.isPlaybackSleep = isPlaybackSleep;
   },
 
   SET_CUSTOM_CONTEXT_URI(state, contextUri) {

--- a/client/store/playback/state.ts
+++ b/client/store/playback/state.ts
@@ -56,7 +56,8 @@ const state = (): PlaybackState => ({
   isSavedTrack: false,
   positionMs: 0,
   disabledPlayingFromBegining: false,
-  durationMs: 0,
+  // if set to 0, Seekbar has 0 length
+  durationMs: 1,
   isShuffled: false,
   repeatMode: undefined,
   disallows: {},

--- a/client/store/playback/state.ts
+++ b/client/store/playback/state.ts
@@ -5,6 +5,7 @@ export type PlaybackState = {
   deviceId: string | undefined
   activeDeviceId: string | undefined
   deviceList: SpotifyAPI.Device[]
+  isPlaybackSleep: boolean
   contextUri: string | undefined
   trackId: string | undefined
   trackName: string | undefined
@@ -37,6 +38,7 @@ const state = (): PlaybackState => ({
   deviceId: undefined,
   activeDeviceId: undefined,
   deviceList: [],
+  isPlaybackSleep: false,
   images: undefined,
   contextUri: undefined,
   trackId: undefined,

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -212,6 +212,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         commit('playback/SET_NEXT_TRACK_LIST', playerState.track_window.next_tracks, { root: true });
         commit('playback/SET_PREVIOUS_TRACK_LIST', playerState.track_window.previous_tracks, { root: true });
         commit('playback/SET_DISALLOWS', playerState.disallows, { root: true });
+        commit('playback/SET_IS_PLAYBACK_SLEEP', false, { root: true });
 
         // 表示がちらつくので、初回以外は player/repeat 内で commit する
         if (currentRepeatMode == null) {

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -110,10 +110,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
           if (accessToken == null) {
             await dispatch('auth/logout', undefined, { root: true });
             this.$router.push('/login');
-            this.$toast.push({
-              color: 'error',
-              message: 'トークンを取得できなかったためログアウトしました。',
-            });
+            this.$toast.pushError('トークンを取得できなかったためログアウトしました。');
             return;
           }
 

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -128,7 +128,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       player.addListener('ready', async ({ device_id }) => {
         commit('playback/SET_DEVICE_ID', device_id, { root: true });
 
-        await dispatch('playback/getActiveDeviceList', undefined, { root: true });
+        await dispatch('playback/getDeviceList', undefined, { root: true });
 
         const currentActiveDevice = this.$getters()['playback/activeDevice'];
         if (currentActiveDevice == null) {

--- a/client/store/player/actions.ts
+++ b/client/store/player/actions.ts
@@ -138,8 +138,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
           ? 30 * 1000
           : 0;
         dispatch('playback/pollCurrentPlayback', firstTimeout, { root: true });
-
-        console.info('Ready with this device 🎉');
+        console.info('Ready with this device 🚀');
       });
 
       // デバイスがオフラインのとき
@@ -185,7 +184,6 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
 
         // @todo
         console.info(playerState);
-
         const {
           trackId: currentTrackId,
           repeatMode: currentRepeatMode,
@@ -203,7 +201,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
         }
 
         commit('playback/SET_IS_PLAYING', !playerState.paused, { root: true });
-        // 表示playback/のちらつきを防ぐためにトラック (duration_ms) をセットしてからセ, { root: true }ット
+        // 表示のちらつきを防ぐためにトラック (duration_ms) をセットしてからセット
         commit('playback/SET_DURATION_MS', playerState.duration, { root: true });
         commit('playback/SET_POSITION_MS', playerState.position, { root: true });
         commit('playback/SET_IS_SHUFFLED', playerState.shuffle, { root: true });
@@ -225,6 +223,7 @@ const actions: Actions<PlayerState, PlayerActions, PlayerGetters, PlayerMutation
       const isConnected = await player.connect();
       if (isConnected) {
         commit('SET_PLAYBACK_PLAYER', player);
+        console.info('Successfully connected this device 🎉');
       }
     };
 

--- a/client/store/playlists/actions.ts
+++ b/client/store/playlists/actions.ts
@@ -69,11 +69,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
       offset,
     });
     if (playlists == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'プレイリストの一覧を取得できませんでした。',
-      });
-
+      this.$toast.pushError('プレイリストの一覧を取得できませんでした。');
       return;
     }
 
@@ -93,10 +89,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
     });
 
     if (firstListOfPlaylists == null) {
-      this.$toast.push({
-        color: 'error',
-        message: 'プレイリストの一覧を取得できませんでした。',
-      });
+      this.$toast.pushError('プレイリストの一覧を取得できませんでした。');
 
       return;
     }
@@ -108,11 +101,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
         limit,
       });
       if (playlists == null) {
-        this.$toast.push({
-          color: 'error',
-          message: 'プレイリストの一部が取得できませんでした。',
-        });
-
+        this.$toast.pushError('プレイリストの一部が取得できませんでした。');
         return [];
       }
 
@@ -259,10 +248,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: 'プレイリストのフォローに失敗しました。',
-        });
+        this.$toast.pushError('プレイリストのフォローに失敗しました。');
       });
   },
 
@@ -278,23 +264,16 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
         commit('REMOVE_PLAYLIST', playlistId);
         commit('SET_ACTUAL_IS_SAVED', [playlistId, false]);
         if (isOwnPlaylist) {
-          this.$toast.push({
-            color: 'primary',
-            message: 'プレイリストを削除しました。',
-          });
-
+          this.$toast.pushPrimary('プレイリストを削除しました。');
           // @todo プレイリスト一覧に飛ばす
           this.$router.replace('/');
         }
       })
       .catch((err: Error) => {
         console.error({ err });
-        this.$toast.push({
-          color: 'error',
-          message: isOwnPlaylist
-            ? 'プレイリストの削除に失敗しました。'
-            : 'プレイリストのフォローの解除に失敗しました。',
-        });
+        this.$toast.pushError(isOwnPlaylist
+          ? 'プレイリストの削除に失敗しました。'
+          : 'プレイリストのフォローの解除に失敗しました。');
       });
   },
 
@@ -316,11 +295,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
     });
 
     if (snapshot_id == null) {
-      this.$toast.push({
-        color: 'error',
-        message: `"${name}" を "${playlistName}" に追加できませんでした。`,
-      });
-
+      this.$toast.pushError(`"${name}" を "${playlistName}" に追加できませんでした。`);
       return;
     }
 
@@ -334,11 +309,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
 
     const currentUnupdatedCounts = state.unupdatedTrackCountsMap.get(playlistId) ?? 0;
     commit('INCREMENT_UNUPDATED_TRACKS_MAP', [playlistId, currentUnupdatedCounts + 1]);
-
-    this.$toast.push({
-      color: 'primary',
-      message: `"${name}" を "${playlistName}" に追加しました。`,
-    });
+    this.$toast.pushPrimary(`"${name}" を "${playlistName}" に追加しました。`);
   },
 
   /**
@@ -354,10 +325,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
     });
 
     if (snapshotId == null) {
-      this.$toast.push({
-        color: 'error',
-        message: `${name}をこのプレイリストから削除できませんでした。`,
-      });
+      this.$toast.pushError(`${name}をこのプレイリストから削除できませんでした。`);
       return;
     }
 
@@ -371,10 +339,7 @@ const actions: Actions<PlaylistsState, PlaylistsActions, PlaylistsGetters, Playl
 
     commit('SET_ACTUALLY_DELETED_TRACK', [playlistId, track]);
 
-    this.$toast.push({
-      color: 'primary',
-      message: `${name}をこのプレイリストから削除しました。`,
-    });
+    this.$toast.pushPrimary(`${name}をこのプレイリストから削除しました。`);
   },
 };
 

--- a/client/utils/request/multipleRequests.ts
+++ b/client/utils/request/multipleRequests.ts
@@ -5,6 +5,10 @@ export const multipleRequests = <T extends Exclude<unknown, void>>(
   length: number,
   limit: number,
 ): Promise<T[]> => {
+  if (length <= 0 || limit <= 0) {
+    return Promise.resolve([]);
+  }
+
   const counts = Math.ceil(length / limit);
   return Promise.all([...new Array(counts)]
     .map((_, i) => handler(i)))

--- a/client/utils/request/multipleRequestsWithId.ts
+++ b/client/utils/request/multipleRequestsWithId.ts
@@ -1,7 +1,9 @@
+import { OneToHundred } from '~~/types';
+
 export const multipleRequestsWithId = <T>(
   request: (ids: string, length: number) => Promise<T>,
   idList: string[],
-  limit: number,
+  limit: OneToHundred,
   callback?: (responseDataList: T[]) => T,
 ): Promise<T> => {
   const { length } = idList;

--- a/types/app/SpotifyAPI.d.ts
+++ b/types/app/SpotifyAPI.d.ts
@@ -446,7 +446,7 @@ export namespace SpotifyAPI {
     href: string
     id: string
     images: Image[]
-    product: string
+    product: 'premium' | 'free' | 'open'
     type: 'user'
     uri: string
   }


### PR DESCRIPTION
## About

- resolve #469 
  - 再生してないときアクティブなデバイスが見つからなくてもデバイスの変更はしない
  - 再生するときに最後にアクティブだったデバイスをアクティブにしてから再生する
- resolve #426
  - プレミアムのアカウント必要な処理は事前にチェック
  - 閲覧はできるようにする
- `PlayerBar` を Composition API に更新
- 複数回リクエストのエラー修正
- ~~`sleep` の場合は `awakePlayback` でプレイヤー操作する前にアクティブにする~~ プレイヤー操作するとき `deviceId` の指定を必須にする ('sleep' でなければ指定はするが `undefined`)
