### PR TITLE
プレイリストの諸々を直す

### DIFF
--- a/client/components/containers/menu/PlaybackMenu.vue
+++ b/client/components/containers/menu/PlaybackMenu.vue
@@ -64,11 +64,11 @@ export default defineComponent({
     }));
     const trackPage = computed(() => useTrackLinkMenu(root, unref(track)));
     const releasePage = computed(() => useReleaseLinkMenu(root, unref(track)));
-    const addItemToPlaylist = useAddItemToPlaylistMenu(unref(track), {
+    const addItemToPlaylist = computed(() => useAddItemToPlaylistMenu(unref(track), {
       publisher: undefined,
       left: true,
       right: false,
-    });
+    }));
     const share = computed(() => {
       const item = unref(track);
       return useShareMenu(item != null

--- a/client/components/containers/menu/PlaylistMenu.vue
+++ b/client/components/containers/menu/PlaylistMenu.vue
@@ -136,7 +136,7 @@ export default defineComponent({
       const type = 'custom';
       const isOwnPlaylist = props.playlist.owner.id === root.$getters()['auth/userId'];
       const handler = () => {
-        emit(ON_FOLLOW_MENU_CLICKED, props.following);
+        emit(ON_FOLLOW_MENU_CLICKED, !props.following);
       };
       return props.following
         ? {

--- a/client/components/containers/table/PlaylistTrackTable.vue
+++ b/client/components/containers/table/PlaylistTrackTable.vue
@@ -229,12 +229,13 @@ export default Vue.extend({
       }
       // trackUriList は更新されうる
       const trackUriList = this.tracks.map((track) => track.uri);
-      // プレイリスト再生の際は position を uri で指定すると、403 が返る場合があるので index で指定
+      // @todo プレイリスト再生の際は offset を uri で指定すると、403 が返る場合がある?
       // ライブラリのお気に入りの曲を再生する場合は contextUri では指定できないので、trackUriList を指定
       this.$dispatch('playback/play', !this.custom && this.uri != null
         ? {
           contextUri: this.uri,
-          offset: { position: row.index },
+          offset: { uri: row.uri },
+          // offset: { position: row.index },
         }
         : {
           trackUriList,

--- a/client/components/parts/text/UserName.test.ts
+++ b/client/components/parts/text/UserName.test.ts
@@ -6,7 +6,16 @@ import type { SpotifyAPI } from '~~/types';
 
 const userName = (i: number) => `display_name${i}`;
 const id = (i: number) => `id${i}`;
-const user = (i: number, hasDisplayName: boolean): SpotifyAPI.UserData => ({
+const image: SpotifyAPI.Image = {
+  url: 'path/to/image',
+  height: 500,
+  width: 500,
+};
+const user = (
+  i: number,
+  hasDisplayName: boolean,
+  images: SpotifyAPI.Image[],
+): SpotifyAPI.UserData => ({
   country: 'JP',
   display_name: hasDisplayName ? userName(i) : null,
   email: 'user@email.com',
@@ -23,47 +32,47 @@ const user = (i: number, hasDisplayName: boolean): SpotifyAPI.UserData => ({
   },
   href: 'href',
   id: id(i),
-  images: [],
+  images,
   product: 'premium',
   type: 'user',
   uri: 'uri',
 });
 
 describe('UserName', () => {
-  it('visible avatar despite no images', () => {
+  it('invisible avatar when no images are valid', () => {
     const wrapper = mount(UserName, {
       ...options,
       propsData: {
-        user: user(1, true),
+        user: user(1, true, []),
         avatar: true,
       },
     });
-    expect(wrapper.findComponent(UserAvatar).exists()).toBe(true);
+    expect(wrapper.findComponent(UserAvatar).exists()).toBe(false);
   });
 
-  it('invisible avatar', () => {
+  it('invisible avatar despite images are valid', () => {
     const wrapper = mount(UserName, {
       ...options,
       propsData: {
-        user: user(1, true),
+        user: user(1, true, [image]),
         avatar: false,
       },
     });
     expect(wrapper.findComponent(UserAvatar).exists()).toBe(false);
   });
 
-  it('modify user name', async () => {
+  it('modify user name to undefined', async () => {
     const wrapper = mount(UserName, {
       ...options,
       propsData: {
-        user: user(1, true),
+        user: user(1, true, []),
       },
     });
     const link = wrapper.find('div > *:last-child');
     expect(link.text()).toBe(userName(1));
 
     await wrapper.setProps({
-      user: user(1, false),
+      user: user(1, false, []),
     });
     expect(link.text()).toBe(id(1));
   });

--- a/client/components/parts/text/UserName.vue
+++ b/client/components/parts/text/UserName.vue
@@ -6,7 +6,7 @@
     }"
   >
     <UserAvatar
-      v-if="avatar"
+      v-if="avatar && src != null"
       type="user"
       :src="src"
       :size="SIZE_OF_AVATAR"


### PR DESCRIPTION
## Overview

- プレイリストのアイテム再生時に、`position` ではなく `uri` で指定するように
  - プレイリストの順番が更新されていて `position` が狂う場合があったので
  - 403 が返る可能性がある？ (未確認)
- `PlaybackMenu` からの「プレイリストへ追加」がトラック変わっても再計算されるように
- プレイリストのフォロー/アンフォロー・削除がうまくいかないのを直す
- `UserName` で avatar の src がないときは表示しない
